### PR TITLE
Fix EnvLoader::load() crash on malformed .env lines

### DIFF
--- a/src/Env/EnvLoader.php
+++ b/src/Env/EnvLoader.php
@@ -12,11 +12,20 @@ class EnvLoader
 
         $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         foreach ($lines as $line) {
-            if (strpos(trim($line), '#') === 0) {
+            $line = trim($line);
+
+            if ($line === '' || str_starts_with($line, '#')) {
                 continue;
             }
 
-            [$name, $value] = array_map('trim', explode('=', $line, 2));
+            if (!str_contains($line, '=')) {
+                continue;
+            }
+
+            [$name, $value] = explode('=', $line, 2);
+            $name  = trim($name);
+            $value = trim($value);
+
             if (!array_key_exists($name, $_ENV)) {
                 $_ENV[$name] = $value;
                 putenv("$name=$value");


### PR DESCRIPTION
## Summary
- Skip whitespace-only lines early by trimming and checking for empty string
- Skip lines without `=` separator to prevent `Undefined array key 1` error from `explode()` destructuring
- Replace `array_map('trim', ...)` with explicit `trim()` calls for clarity

Closes #1

## Test plan
- [x] `APP_NAME=Dromos` → sets `$_ENV['APP_NAME']` to `'Dromos'`
- [x] `MALFORMED_LINE` (no `=`) → silently skipped, no error
- [x] `# This is a comment` → skipped
- [x] Whitespace-only line (`"   	  "`) → skipped
- [x] `EMPTY_KEY=` → sets `$_ENV['EMPTY_KEY']` to `''`
- [x] `DB_URL=postgres://u:p@host/db?opt=1` → preserves full value with `=` characters
- [x] `  # indented comment` → skipped (handled by pre-trimming)
- [x] `export FOO` (no `=`) → skipped